### PR TITLE
[*] 在 README 中添加示例项目 pjson

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,6 @@ Go Parsec2 改写了 [goParsec](http://github.com/Dwarfartisan/goParsec) 。在�
 Go Parsec2中，bind 不再是一个 Parsec 算子，而是所有 Parsec 算子的 Monad 特征。所有的 Parsec 算子都组合为带 Bind/Then/Over 的结构。 Go Parsec 2 提供了一些方法简化这些封装操作。
 
 提供了 Do 形式。
+
+## 使用 Go Parsec2 编写的解析器
+* [pjson: a json parser using goparsec2](https://github.com/damonchen/pjson)


### PR DESCRIPTION
goparsec2 缺乏示例，没有 haskell parsec 基础的人学习起来有点困难，添加一个可用的 json parser 示例方便学习。